### PR TITLE
#101 driver.findElement() and element.findElement() must throw NoSuchElementException if element is not found.

### DIFF
--- a/src/main/java/org/brit/driver/PlaywrightiumDriver.java
+++ b/src/main/java/org/brit/driver/PlaywrightiumDriver.java
@@ -9,6 +9,7 @@ import com.microsoft.playwright.options.ViewportSize;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.commons.text.CaseUtils;
+import org.brit.driver.adapters.FindElementAdapter;
 import org.brit.element.PlaywrightWebElement;
 import org.brit.emulation.Device;
 import org.brit.locators.ArialSearchOptions;
@@ -218,19 +219,12 @@ public class PlaywrightiumDriver extends RemoteWebDriver implements TakesScreens
 
     @Override
     public List<WebElement> findElements(By by) {
-        return getLocatorFromBy(by).all()
-                .stream().map(PlaywrightWebElement::new)
-                .collect(Collectors.toUnmodifiableList());
+        return FindElementAdapter.findElements(getLocatorFromBy(by));
     }
 
     @Override
     public WebElement findElement(By by) {
-      try {
-        getLocatorFromBy(by).first().waitFor(elementExists);
-      } catch (TimeoutError e) {
-        throw new NoSuchElementException("Unable to locate element: " + by, e);
-      }
-      return new PlaywrightWebElement(getLocatorFromBy(by).first());
+        return FindElementAdapter.findElement(getLocatorFromBy(by), by);
     }
 
     private Locator getLocatorFromBy(By by) {

--- a/src/main/java/org/brit/driver/adapters/FindElementAdapter.java
+++ b/src/main/java/org/brit/driver/adapters/FindElementAdapter.java
@@ -1,0 +1,51 @@
+package org.brit.driver.adapters;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.TimeoutError;
+import org.brit.element.PlaywrightWebElement;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidSelectorException;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.microsoft.playwright.options.WaitForSelectorState.ATTACHED;
+
+public class FindElementAdapter {
+    private static final Pattern INVALID_SELECTOR = Pattern.compile("(is not a valid XPath expression|Unexpected token \".*?\" while parsing selector)");
+    private static final Locator.WaitForOptions elementExists = new Locator.WaitForOptions().setState(ATTACHED);
+
+    public static List<WebElement> findElements(Locator locator) {
+        List<WebElement> collect = null;
+        try {
+            collect = locator.all()
+                    .stream().map(PlaywrightWebElement::new)
+                    .collect(Collectors.toUnmodifiableList());
+        } catch (PlaywrightException e) {
+            if (INVALID_SELECTOR.matcher(e.getMessage()).find()) {
+                throw new InvalidSelectorException(e.getMessage());
+            }
+            throw e;
+        }
+        return collect;
+    }
+
+    public static WebElement findElement(Locator locator, By by) {
+        try {
+          locator.first().waitFor(elementExists);
+        } catch (TimeoutError e) {
+            throw new NoSuchElementException("Unable to locate element: " + by, e);
+        } catch (PlaywrightException e) {
+            if (INVALID_SELECTOR.matcher(e.getMessage()).find()) {
+                throw new InvalidSelectorException(e.getMessage());
+            }
+            throw e;
+        }
+        return new PlaywrightWebElement(locator.first());
+    }
+
+}

--- a/src/main/java/org/brit/element/PlaywrightWebElement.java
+++ b/src/main/java/org/brit/element/PlaywrightWebElement.java
@@ -4,6 +4,7 @@ import com.microsoft.playwright.*;
 import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.BoundingBox;
 import org.apache.commons.text.CaseUtils;
+import org.brit.driver.adapters.FindElementAdapter;
 import org.brit.locators.ArialSearchOptions;
 import org.openqa.selenium.*;
 import org.openqa.selenium.remote.RemoteWebElement;
@@ -15,9 +16,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static com.microsoft.playwright.options.WaitForSelectorState.ATTACHED;
 
 /**
  * @author Serhii Bryt
@@ -25,8 +23,6 @@ import static com.microsoft.playwright.options.WaitForSelectorState.ATTACHED;
  * @see org.openqa.selenium.WebElement
  */
 public class PlaywrightWebElement extends RemoteWebElement {
-
-    private static final Locator.WaitForOptions elementExists = new Locator.WaitForOptions().setState(ATTACHED);
     Locator locator;
     ElementHandle elementHandle;
 
@@ -134,19 +130,12 @@ public class PlaywrightWebElement extends RemoteWebElement {
 
     @Override
     public List<WebElement> findElements(By by) {
-        return getLocatorFromBy(by).all()
-                .stream().map(PlaywrightWebElement::new)
-                .collect(Collectors.toUnmodifiableList());
+        return FindElementAdapter.findElements(getLocatorFromBy(by));
     }
 
     @Override
     public WebElement findElement(By by) {
-        try {
-            getLocatorFromBy(by).first().waitFor(elementExists);
-        } catch (TimeoutError e) {
-            throw new NoSuchElementException("Unable to locate element: " + by, e);
-        }
-        return new PlaywrightWebElement(getLocatorFromBy(by).first());
+        return FindElementAdapter.findElement(getLocatorFromBy(by), by);
     }
 
     private Locator getLocatorFromBy(By by) {

--- a/src/main/java/org/brit/element/PlaywrightWebElement.java
+++ b/src/main/java/org/brit/element/PlaywrightWebElement.java
@@ -17,6 +17,8 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.microsoft.playwright.options.WaitForSelectorState.ATTACHED;
+
 /**
  * @author Serhii Bryt
  * WebElement implementation
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
  */
 public class PlaywrightWebElement extends RemoteWebElement {
 
+    private static final Locator.WaitForOptions elementExists = new Locator.WaitForOptions().setState(ATTACHED);
     Locator locator;
     ElementHandle elementHandle;
 
@@ -138,6 +141,11 @@ public class PlaywrightWebElement extends RemoteWebElement {
 
     @Override
     public WebElement findElement(By by) {
+        try {
+            getLocatorFromBy(by).first().waitFor(elementExists);
+        } catch (TimeoutError e) {
+            throw new NoSuchElementException("Unable to locate element: " + by, e);
+        }
         return new PlaywrightWebElement(getLocatorFromBy(by).first());
     }
 


### PR DESCRIPTION
Fixes #101: methods `driver.findElement()` and `element.findElement()` must throw `NoSuchElementException` if the element is not found.